### PR TITLE
Fix pokemon type list and error display

### DIFF
--- a/src/app/pokemon/pokemon-add/pokemon-add.component.html
+++ b/src/app/pokemon/pokemon-add/pokemon-add.component.html
@@ -35,7 +35,7 @@
                       <div class="invalid-feedback">
                         Le nom du Pokémon est requis.
                       </div>
-                    } @else if (pokemonName.hasError('required')) {
+                    } @else if (pokemonName.hasError('minlength')) {
                       <div class="invalid-feedback">
                         Le nom du Pokémon doit contenir au moins
                         {{ pokemonName.getError('minlength').requiredLength }}

--- a/src/app/service/pokemon.service.ts
+++ b/src/app/service/pokemon.service.ts
@@ -35,6 +35,24 @@ export class PokemonService {
   }
 
   getPokemonTypesList(): string[] {
-    return ['Plante', ' Poison', 'Feu', 'Eau', 'Insecte', ' Normal', ' Vol', 'Spectre', 'Fée', 'Combat', 'Sol', 'Electrik', 'Acier', 'Psychique', 'Glace', 'Dragon', 'Ténèbres'];
+    return [
+      'Plante',
+      'Poison',
+      'Feu',
+      'Eau',
+      'Insecte',
+      'Normal',
+      'Vol',
+      'Spectre',
+      'Fée',
+      'Combat',
+      'Sol',
+      'Electrik',
+      'Acier',
+      'Psychique',
+      'Glace',
+      'Dragon',
+      'Ténèbres',
+    ];
   }
 }


### PR DESCRIPTION
## Summary
- ensure `PokemonService.getPokemonTypesList` returns trimmed type names
- fix `pokemon-add` validation check for minlength

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684872c7db9c8327b527625def2ac9e7